### PR TITLE
Fix game panel title display

### DIFF
--- a/client/src/common/choicescript-compiler.ts
+++ b/client/src/common/choicescript-compiler.ts
@@ -3,7 +3,7 @@ import type { IWorkspaceProvider } from './interfaces/vscode-workspace-provider'
 
 export type AllScenesResult = { [key: string]: { labels: { [key: string]: number }, lines: string[] }; }
 export type CompiledChoiceScriptGame = {
-	title: string,
+	title?: string,
 	scenes: AllScenesResult
 }
 

--- a/client/src/common/game-web-view.ts
+++ b/client/src/common/game-web-view.ts
@@ -21,14 +21,12 @@ export class GameWebViewManager {
 	}
 
 	public async runCompiledGame(game: CompiledChoiceScriptGame) {
-		this.openOrShow(game.title);
+		this.windowTitle = game.title ?? "Untitled";
+		this.openOrShow();
 		this.panel.webview.html = (await this.getWebviewContent(game.scenes)).toString();
 	}
 
-	public openOrShow(title?: string) {
-		if (title) {
-			this.windowTitle = title;
-		}
+	public openOrShow() {
 		if (this.panel) {
 			this.panel.reveal();
 		} else {
@@ -44,6 +42,7 @@ export class GameWebViewManager {
 			);
 			this.registerPanelSubscriptions();
 		}
+		this.panel.title = this.windowTitle;
 	}
 
 	private async getWebviewContent(allScenes: AllScenesResult): Promise<string> {


### PR DESCRIPTION
The title of the game panel will always show "Loading...", regardless of whether a *title command exists, due to a bug. This PR fixes that bug and also adds an "Untitled" default title for games without a *title command.

**Before**
<img width="295" alt="Screenshot 2024-11-06 at 22 56 42" src="https://github.com/user-attachments/assets/c4a3d271-aa7a-4015-bca6-48a52558b0f2">

**After (No \*title)**
<img width="679" alt="Screenshot 2024-11-06 at 23 07 36" src="https://github.com/user-attachments/assets/d7309d3a-7bf6-42cc-9dc2-49811cc44239">

**After (\*title)**
<img width="681" alt="Screenshot 2024-11-06 at 23 08 48" src="https://github.com/user-attachments/assets/db7771fb-c20b-4922-94ba-80a1997208d3">
